### PR TITLE
Support changing mode for $GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ To install Go packages using node attributes, include `golang::packages` in your
     <td>The group that owns $GOPATH</td>
     <td><tt>root</tt></td>
   </tr>
+  <tr>
+    <td><tt>['go']['mode']</tt></td>
+    <td>String</td>
+    <td>The mode of $GOPATH</td>
+    <td><tt>0755</tt></td>
+  </tr>
 </table>
 
 ## <a name="testing"></a> Testing

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,3 +9,4 @@ default['go']['scm'] = true
 default['go']['packages'] = []
 default['go']['owner'] = 'root'
 default['go']['group'] = 'root'
+default['go']['mode'] = 0755

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,7 +40,7 @@ directory node['go']['gopath'] do
   recursive true
   owner node['go']['owner']
   group node['go']['group']
-  mode 0755
+  mode node['go']['mode']
 end
 
 directory node['go']['gobin'] do
@@ -48,7 +48,7 @@ directory node['go']['gobin'] do
   recursive true
   owner node['go']['owner']
   group node['go']['group']
-  mode 0755
+  mode node['go']['mode']
 end
 
 template "/etc/profile.d/golang.sh" do


### PR DESCRIPTION
Added `mode` attribute which enables to change permission of `$GOPATH`.
It's useful to allow giving write permission to group in the go directory.