### PR TITLE
Update cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,29 +1,21 @@
 ---
-driver_plugin: vagrant
-driver_config:
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
   require_chef_omnibus: true
 
 platforms:
-
 - name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_chef-11.4.4.box
-  run_list:
-    - recipe[apt]
 - name: centos-6.5
-  driver:
-    box: opscode-centos-6.5
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.5_chef-11.4.4.box
-  run_list:
-    - recipe[yum]
 
 suites:
 - name: default
   run_list:
     - recipe[golang_test::default]
     - recipe[minitest-handler]
-  attributes: 
-    go: 
+  attributes:
+    go:
       owner: 'vagrant'
       group: 'vagrant'

--- a/Berksfile
+++ b/Berksfile
@@ -1,10 +1,8 @@
-site :opscode
+source "https://supermarket.getchef.com"
 
 metadata
 
 group :integration do
-  cookbook 'apt'
-  cookbook 'yum'
   cookbook "minitest-handler"
   cookbook 'golang_test', path: 'test/cookbooks/golang_test'
 end

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -1,8 +1,8 @@
 action :install do
 
-  tmp_file_path = ::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(/\//, '-') 
+  tmp_file_path = ::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(/\//, '-')
 
-  bash "#{node['go']['install_dir']}/go/bin/go get -v #{new_resource.name} 2> >(grep -v '(download)$' > #{tmp_file_path})" do
+  bash "Installing package #{new_resource.name}" do
     code "#{node['go']['install_dir']}/go/bin/go get -v #{new_resource.name} 2> >(grep -v '(download)$' > #{tmp_file_path})"
     action :nothing
     user node['go']['owner']
@@ -23,9 +23,9 @@ end
 
 action :update do
 
-  tmp_file_path = ::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(/\//, '-') 
+  tmp_file_path = ::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(/\//, '-')
 
-  bash "#{node['go']['install_dir']}/go/bin/go get -v -u #{new_resource.name} 2> >(grep -v '(download)$' > #{tmp_file_path})" do
+  bash "Updating package #{new_resource.name}" do
     code "#{node['go']['install_dir']}/go/bin/go get -v -u #{new_resource.name} 2> >(grep -v '(download)$' > #{tmp_file_path})"
     action :nothing
     user node['go']['owner']
@@ -56,7 +56,7 @@ action :build do
   # create temporary directory to executing the build in
   tmpdir.run_action(:create)
 
-  b = bash "Build #{new_resource.name}" do
+  b = bash "Build package #{new_resource.name}" do
     code "#{node['go']['install_dir']}/go/bin/go build #{new_resource.name}"
     action :nothing
     cwd tmpdir.name
@@ -72,7 +72,7 @@ action :build do
   b.run_action(:run)
 
   # remove temporary directory
-  tmpdir.run_action(:delete)
+  # tmpdir.run_action(:delete)
 
   new_resource.updated_by_last_action(b.updated?)
 end

--- a/test/cookbooks/golang_test/CHANGELOG.md
+++ b/test/cookbooks/golang_test/CHANGELOG.md
@@ -1,10 +1,10 @@
-# CHANGELOG for chef_golang_test
+# CHANGELOG for golang_test
 
-This file is used to list changes made in each version of chef_golang_test.
+This file is used to list changes made in each version of golang_test.
 
 ## 0.1.0:
 
-* Initial release of chef_golang_test
+* Initial release of golang_test
 
 - - -
 Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.

--- a/test/cookbooks/golang_test/README.md
+++ b/test/cookbooks/golang_test/README.md
@@ -1,4 +1,4 @@
-chef_golang_test Cookbook
+golang_test Cookbook
 =========================
 TODO: Enter the cookbook description here.
 
@@ -11,14 +11,14 @@ TODO: List your cookbook requirements. Be sure to include any requirements this 
 
 e.g.
 #### packages
-- `toaster` - chef_golang_test needs toaster to brown your bagel.
+- `toaster` - golang_test needs toaster to brown your bagel.
 
 Attributes
 ----------
 TODO: List you cookbook attributes here.
 
 e.g.
-#### chef_golang_test::default
+#### golang_test::default
 <table>
   <tr>
     <th>Key</th>
@@ -27,7 +27,7 @@ e.g.
     <th>Default</th>
   </tr>
   <tr>
-    <td><tt>['chef_golang_test']['bacon']</tt></td>
+    <td><tt>['golang_test']['bacon']</tt></td>
     <td>Boolean</td>
     <td>whether to include bacon</td>
     <td><tt>true</tt></td>
@@ -36,17 +36,17 @@ e.g.
 
 Usage
 -----
-#### chef_golang_test::default
+#### golang_test::default
 TODO: Write usage instructions for each cookbook.
 
 e.g.
-Just include `chef_golang_test` in your node's `run_list`:
+Just include `golang_test` in your node's `run_list`:
 
 ```json
 {
   "name":"my_node",
   "run_list": [
-    "recipe[chef_golang_test]"
+    "recipe[golang_test]"
   ]
 }
 ```

--- a/test/cookbooks/golang_test/metadata.rb
+++ b/test/cookbooks/golang_test/metadata.rb
@@ -1,11 +1,11 @@
-name             'chef_golang_test'
+name             'golang_test'
 maintainer       'YOUR_COMPANY_NAME'
 maintainer_email 'YOUR_EMAIL'
 license          'All rights reserved'
-description      'Installs/Configures chef_golang_test'
+description      'Installs/Configures golang_test'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-recipe "golang_test", ""
+recipe "golang_test", "default"
 
 depends 'golang'

--- a/test/cookbooks/golang_test/recipes/default.rb
+++ b/test/cookbooks/golang_test/recipes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: chef_golang_test
+# Cookbook Name:: golang_test
 # Recipe:: default
 #
 # Copyright 2013, YOUR_COMPANY_NAME


### PR DESCRIPTION
This commit is to update the cookbook to the latest at the moment,
it updated the Berksfile and validate that the right cookbook name
for `golang_test` is well configured.

Changed the provider with a nice output. Though it need more work.

Also deleted some stuff from `.kitchen.yml` and added chef-zero
instead of chef-solo.