### PR TITLE
Remove derived attributes, to allow changing Go version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,4 @@
 default['go']['version'] = '1.4'
-default['go']['platform'] = node['kernel']['machine'] =~ /i.86/ ? '386' : 'amd64'
-default['go']['filename'] = "go#{node['go']['version']}.#{node['os']}-#{node['go']['platform']}.tar.gz"
-default['go']['url'] = "http://golang.org/dl/#{node['go']['filename']}"
 default['go']['install_dir'] = '/usr/local'
 default['go']['gopath'] = '/opt/go'
 default['go']['gobin'] = '/opt/go/bin'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,18 +17,22 @@
 # under the License.
 #
 
+go_platform = node['kernel']['machine'] =~ /i.86/ ? '386' : 'amd64'
+go_filename = "go#{node['go']['version']}.#{node['os']}-#{go_platform}.tar.gz"
+go_url = "http://golang.org/dl/#{go_filename}"
+
 bash "install-golang" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
     rm -rf go
     rm -rf #{node['go']['install_dir']}/go
-    tar -C #{node['go']['install_dir']} -xzf #{node["go"]["filename"]}
+    tar -C #{node['go']['install_dir']} -xzf #{go_filename}
   EOH
   action :nothing
 end
 
-remote_file File.join(Chef::Config[:file_cache_path], node['go']['filename']) do
-  source node['go']['url']
+remote_file File.join(Chef::Config[:file_cache_path], go_filename) do
+  source go_url
   owner 'root'
   mode 0644
   notifies :run, 'bash[install-golang]', :immediately


### PR DESCRIPTION
Since platform, filename, and url are computed in the attribute file,
changing node['go']['version'] afterwards, for instance in a wrapper
cookbook, will not work.  Since those values are not documented as
attributes anyway, just remove them and compute them as variables in the
recipe instead.