### PR TITLE
Don't hide the "go get" output from the normal output

### DIFF
--- a/providers/package.rb
+++ b/providers/package.rb
@@ -3,7 +3,7 @@ action :install do
   tmp_file_path = ::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(/\//, '-')
 
   bash "Installing package #{new_resource.name}" do
-    code "#{node['go']['install_dir']}/go/bin/go get -v #{new_resource.name} 2> >(grep -v '(download)$' > #{tmp_file_path})"
+    code "#{node['go']['install_dir']}/go/bin/go get -v #{new_resource.name} 2> >(grep -v '(download)$' | tee #{tmp_file_path})"
     action :nothing
     user node['go']['owner']
     group node['go']['group']
@@ -26,7 +26,7 @@ action :update do
   tmp_file_path = ::File.join Chef::Config[:file_cache_path], new_resource.name.gsub(/\//, '-')
 
   bash "Updating package #{new_resource.name}" do
-    code "#{node['go']['install_dir']}/go/bin/go get -v -u #{new_resource.name} 2> >(grep -v '(download)$' > #{tmp_file_path})"
+    code "#{node['go']['install_dir']}/go/bin/go get -v -u #{new_resource.name} 2> >(grep -v '(download)$' | tee #{tmp_file_path})"
     action :nothing
     user node['go']['owner']
     group node['go']['group']


### PR DESCRIPTION
I don't know what the background is here, so I'm looking for feedback.  The cookbook currently redirects all output from `go get` to temporary files.  So when `go get` fails, you don't see any output in the normal chef client log.  I think this is pretty inconvenient.  Is the output too bulky, or confidential?  I haven't seen that sort of thing so far.

So my suggestion is to tee the output to the file, for those who like that, and to the normal output.