### PR TITLE
Add metadata backwards compatibility for Chef 11

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,6 @@
 name             'golang'
-source_url       'https://github.com/NOX73/chef-golang'
-issues_url       'https://github.com/NOX73/chef-golang/issues'
+source_url       'https://github.com/NOX73/chef-golang' if respond_to?(:source_url)
+issues_url       'https://github.com/NOX73/chef-golang/issues' if respond_to?(:issues_url)
 maintainer       'Alexander Rozhnov'
 maintainer_email 'gnox73@gmail.com'
 license          'Apache 2.0'


### PR DESCRIPTION
Solves this issue by adding backwards compatibility for the method calls `source_url` and `issues_url` called in the metadata.rb file: https://github.com/NOX73/chef-golang/issues/61