### PR TITLE
Template should use attribute settings

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -94,9 +94,9 @@ end
 
 template "/etc/profile.d/golang.sh" do
   source "golang.sh.erb"
-  owner 'root'
-  group 'root'
-  mode 0755
+  owner node['go']['owner']
+  group node['go']['group']
+  mode node['go']['mode']
 end
 
 if node['go']['scm']


### PR DESCRIPTION
This adds support for mac platforms by allowing the attribute `default['go']['group']` to be modified from `root` to `wheel`.

Tested on Mac version 10.11.6